### PR TITLE
Add dev guide, path fixes and refactor tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "python.analysis.extraPaths": [
+        "./src"
+    ]
+}

--- a/devguide/DevelopingWebBasedComponents.md
+++ b/devguide/DevelopingWebBasedComponents.md
@@ -1,0 +1,228 @@
+# 🌐 AddasuSec Developer Guide: Writing and Wiring Web Components
+
+This guide walks through creating, running, and connecting web components using the **secure API server** in AddasuSec, then validating the setup using the scripts in `tests/WebServerTests`.
+
+It is based on the current runtime/server code and test flows in this repository.
+
+---
+
+## What this guide covers
+
+You will learn how to:
+
+1. Start the secure remote orchestration server (`src/API/SecureWebAPIServer.py`).
+2. Build a web-based component graph (Calculator + Adder + Subber + Start component).
+3. Connect/disconnect components through the remote runtime API.
+4. Validate behavior using `tests/WebServerTests/mainWebServerRemote.py` and `tests/WebServerTests/mainWebServerSecure.py`.
+
+---
+
+## Prerequisites
+
+- Python 3.9+
+- Repository cloned locally
+- `PYTHONPATH` set so `src/` is importable
+- Required Python dependencies installed (for example: `falcon`, `PyJWT`, `requests`)
+
+From repository root:
+
+```bash
+export PYTHONPATH="$PWD/src"
+```
+
+---
+
+## 1) Start the secure web API server
+
+The secure server exposes the orchestration endpoints:
+
+- `POST /create`
+- `POST /delete`
+- `POST /connect`
+- `POST /disconnect`
+- `POST /start`
+
+Default bind/port: `0.0.0.0:8654`.
+
+Run it from repo root:
+
+```bash
+export PYTHONPATH="$PWD/src"
+python src/API/SecureWebAPIServer.py
+```
+
+Expected startup output:
+
+```text
+Starting API server on 0.0.0.0:8654...
+Serving on http://0.0.0.0:8654
+```
+
+> The secure server includes JWT-aware logging middleware. If a bearer token is provided in `Authorization`, user/roles are decoded and included in request logs.
+
+---
+
+## 2) Component topology used by WebServerTests
+
+The web-server tests build this topology:
+
+- `Start1` (`Examples.CalculatorStart`, runtime type `web`)
+- `Calculator1` (`Examples.Calculator`, runtime type `web_server`)
+- `Calculator2` (`Examples.Calculator`, runtime type `web_server`)
+- `Adder1` (`Examples.Adder`, runtime type `plain`)
+- `Subber1` (`Examples.Subber`, runtime type `plain`)
+
+Primary interface wiring:
+
+- `Start1` → `Calculator1` via `Examples.ICalculate`
+- `Calculator1` → `Adder1` via `Examples.IAdd`
+- `Calculator2` → `Adder1` via `Examples.IAdd`
+- `Calculator1` → `Subber1` via `Examples.ISub`
+- `Calculator2` → `Subber1` via `Examples.ISub`
+
+The remote test script that exercises this graph is:
+
+```bash
+python tests/WebServerTests/mainWebServerRemote.py
+```
+
+---
+
+## 3) End-to-end run sequence (recommended)
+
+Open two terminals.
+
+### Terminal A: Start orchestration API
+
+```bash
+export PYTHONPATH="$PWD/src"
+python src/API/SecureWebAPIServer.py
+```
+
+### Terminal B: Build, connect, and run remote graph
+
+```bash
+export PYTHONPATH="$PWD/src"
+python tests/WebServerTests/mainWebServerRemote.py
+```
+
+What this script does:
+
+1. Creates components remotely using `runtime.remoteCreate(...)`.
+2. Tests duplicate creation failure (intentional).
+3. Connects components remotely using `runtime.remoteConnect(...)`.
+4. Starts the graph with `runtime.remoteStart(...)`.
+5. Disconnects/reconnects interfaces and starts again.
+6. Performs metadata checks and prints graph introspection.
+
+---
+
+## 4) Secure invocation flow
+
+For authenticated web component calls, use:
+
+```bash
+export PYTHONPATH="$PWD/src"
+python tests/WebServerTests/mainWebServerSecure.py
+```
+
+This script:
+
+- Creates secure variants (`CalculatorAuthZ`, `AdderAuthZ`, `SubberAuthZ`).
+- Connects them through runtime type `web_server`.
+- Fetches a bearer token from `http://localhost:8676/token`.
+- Verifies unauthorized requests fail and authorized requests succeed.
+- Performs metadata, connection, and component lifecycle checks.
+
+> Note: `mainWebServerSecure.py` expects an auth/token service running at port `8676`. Start that service separately before running this test.
+
+---
+
+## 5) Useful direct API payloads (for debugging)
+
+If you want to call the server directly, these are the payload shapes expected by the Falcon resources.
+
+### Create
+
+```json
+{
+  "type": "web_server",
+  "module": "Examples.Calculator",
+  "component": "Calculator1",
+  "secure": false
+}
+```
+
+### Connect
+
+```json
+{
+  "type": "web_server",
+  "component_src": "Calculator1",
+  "component_intf": "Adder1",
+  "intf_type": "Examples.IAdd"
+}
+```
+
+### Start
+
+```json
+{
+  "type": "web",
+  "component_id": "Start1"
+}
+```
+
+---
+
+## 6) Troubleshooting
+
+### `ModuleNotFoundError` for local packages
+
+Set `PYTHONPATH` correctly:
+
+```bash
+export PYTHONPATH="$PWD/src"
+```
+
+### `Connection refused` to `localhost:8654`
+
+Ensure `SecureWebAPIServer.py` is running and listening on port `8654`.
+
+### Auth failures in secure test
+
+- Confirm token service is up at `http://localhost:8676/token`.
+- Confirm test credentials are valid (`alice` / `password123` in current test script).
+
+### Duplicate component creation errors
+
+This is expected in the remote test; duplicate creation is intentionally exercised as a negative test.
+
+---
+
+## 7) Quick command summary
+
+```bash
+# from repo root
+export PYTHONPATH="$PWD/src"
+
+# terminal A
+python src/API/SecureWebAPIServer.py
+
+# terminal B (remote create/connect/start flow)
+python tests/WebServerTests/mainWebServerRemote.py
+
+# terminal B (secure authz flow)
+python tests/WebServerTests/mainWebServerSecure.py
+```
+
+---
+
+## 8) Reference files
+
+- `src/API/SecureWebAPIServer.py`
+- `src/API/WebAPI.py`
+- `src/Runtimes/runtime.py`
+- `tests/WebServerTests/mainWebServerRemote.py`
+- `tests/WebServerTests/mainWebServerSecure.py`
+

--- a/devguide/WritingComponentsGuide.md
+++ b/devguide/WritingComponentsGuide.md
@@ -185,5 +185,3 @@ The AddasuSec framework enables secure, adaptive component systems. Following in
 > 🧠 Want more? Extend this with logging, dynamic switching, or trust-policy tagging.
 
 ---
-
-Let us know if you want a CLI wizard or GUI for building components. Happy building! 🔧

--- a/src/API/WebAPI.py
+++ b/src/API/WebAPI.py
@@ -4,6 +4,11 @@ from Runtimes.runtime import runtime
 from MetaArchitecture.MetaArchitecture import MetaArchitecture  # Assume this module is available
 
 
+"""
+Implementation of the runtime API. Create/Delete/Connect/Disconnect.
+
+"""
+
 # Initialize MetaArchitecture and runtime instances
 meta = MetaArchitecture()
 rt = runtime(meta)

--- a/src/Runtimes/WebRuntime.py
+++ b/src/Runtimes/WebRuntime.py
@@ -1,3 +1,14 @@
+import sys
+from pathlib import Path
+
+# Allow the script to be executed directly from ``tests/LocalTests`` while still
+# importing packages from the repository's ``src`` layout.
+PROJECT_SRC = Path(__file__).resolve().parents[2] / "src"
+if str(PROJECT_SRC) not in sys.path:
+    # Prefer the checked-out source tree over any globally installed version.
+    sys.path.insert(0, str(PROJECT_SRC))
+
+
 import importlib
 import inspect
 from typing import get_type_hints

--- a/tests/LocalTests/main.py
+++ b/tests/LocalTests/main.py
@@ -1,195 +1,224 @@
-"""
-Component Lifecycle and Connection Testing Script
---------------------------------------------------
+"""Local integration checks for Addasu component lifecycle and wiring.
 
-This script validates the creation, deletion, connection, and disconnection of components
-within a dynamic component framework (Addasu). It also tests metadata manipulation,
-interface listing, and connection queries using `MetaArchitecture`.
-
-Features:
-- Component instantiation and deletion
-- Interface connection/disconnection
-- Metadata tagging and retrieval
-- Structural verification using assertions (test-like style)
-- Runtime and metadata logging
-
-Intended for internal test and debug use.
-
-Dependencies:
-- AddasuSec.Receptacle
-- Runtimes.runtime
-- MetaArchitecture.MetaArchitecture
-
-Author: Paul Grace
-
+This script exercises component creation, connection management, metadata
+updates, and basic introspection against the local runtime. It is written as an
+executable test script rather than a `unittest` module because the surrounding
+project appears to use direct runtime assertions for local validation.
 """
 
-from AddasuSec.Receptacle import Receptacle
-from Runtimes.runtime import runtime, ComponentException, ConnectionException
-from MetaArchitecture.MetaArchitecture import MetaArchitecture
 import sys
+from pathlib import Path
 
-# === Constants ===
+# Resolve the repository's ``src`` directory so the script can be run directly
+# from ``tests/LocalTests`` without first installing the project into the active
+# Python environment.
+PROJECT_SRC = Path(__file__).resolve().parents[2] / "src"
+if str(PROJECT_SRC) not in sys.path:
+    # Prepend the path so the local checkout takes precedence over any older
+    # globally installed copy of the package.
+    sys.path.insert(0, str(PROJECT_SRC))
 
-PLAIN = "plain"
+from MetaArchitecture.MetaArchitecture import MetaArchitecture
+from Runtimes.runtime import ComponentException, runtime
 
-# Component names
+RUNTIME_TYPE = "plain"
+
+# Stable component labels used throughout the test so that metadata and
+# introspection queries can refer to the same identifiers after creation.
 CALC1_NAME = "Calculator1"
 CALC2_NAME = "Calculator2"
 ADDER_NAME = "Adder1"
 SUBBER_NAME = "Subber1"
 
-# Interfaces
+# Interface identifiers expected by the example components.
 IADD = "Examples.IAdd"
 ISUB = "Examples.ISub"
 
-# Classes
+# Concrete classes instantiated by the runtime during the lifecycle tests.
 CALC_CLASS = "Examples.Calculator"
 ADDER_CLASS = "Examples.Adder"
 SUBBER_CLASS = "Examples.Subber"
 
-# === Initialize runtime and metadata ===
+# ``MetaArchitecture`` records the structural model, while ``runtime`` performs
+# creation, connection, and deletion against that model.
+meta = MetaArchitecture()
+local_runtime = runtime(meta)
 
-addasuMeta = MetaArchitecture()
-addasuSec = runtime(addasuMeta)
 
-# === Function Definitions ===
+def create_component(component_class, label):
+    """Create a component and stop the script with context if creation fails."""
+    try:
+        return local_runtime.create(RUNTIME_TYPE, component_class, label, False)
+    except ComponentException as exc:
+        # Component creation is a prerequisite for the remaining checks, so fail
+        # fast with a useful message instead of letting later assertions cascade.
+        sys.exit(f"Component creation failed for {label}: {exc}")
 
-def run_tests():
-    """Perform basic add and subtract operations to verify component connectivity."""
+
+def expect_component_error(action, description):
+    """Run an action that should fail with a component-level validation error."""
+    try:
+        action()
+    except ComponentException as exc:
+        # These failures are part of the expected behavior, so report them and
+        # continue rather than treating them as test failures.
+        print(f"Expected failure for {description}: {exc}")
+        return
+    raise AssertionError(f"Expected ComponentException for {description}")
+
+
+def connect_all(calc1, calc2, add1, sub1):
+    """Connect both calculators to the adder and subber services."""
+    # Each assert confirms that the runtime accepted the requested wiring and
+    # updated the internal model accordingly.
+    assert local_runtime.connect(RUNTIME_TYPE, calc1, add1, IADD)
+    assert local_runtime.connect(RUNTIME_TYPE, calc2, add1, IADD)
+    assert local_runtime.connect(RUNTIME_TYPE, calc1, sub1, ISUB)
+    assert local_runtime.connect(RUNTIME_TYPE, calc2, sub1, ISUB)
+    print("All components successfully connected")
+
+
+def assert_basic_operations(calc1, calc2):
+    """Verify that both calculators can delegate add and subtract calls."""
+    # The calculator components expose the public API; successful results here
+    # prove that the connected adder and subber dependencies are reachable.
     assert calc1.add(1, 2) == 3
     assert calc2.add(1, 2) == 3
     assert calc1.sub(8, 2) == 6
     assert calc2.sub(8, 2) == 6
     print("Basic math operation tests passed")
 
-def full_connection():
-    """Connect calculators to the adder and subber components via required interfaces."""
-    assert addasuSec.connect(PLAIN, calc1, add1, IADD)
-    assert addasuSec.connect(PLAIN, calc2, add1, IADD)
-    assert addasuSec.connect(PLAIN, calc1, sub1, ISUB)
-    assert addasuSec.connect(PLAIN, calc2, sub1, ISUB)
-    print("All components successfully connected")
 
-# === Component Lifecycle Tests ===
+def disconnect_and_assert_failures(calc1, calc2, add1, sub1):
+    """Disconnect each dependency and ensure the delegated call no longer works."""
+    # Pair each disconnection with the operation that should fail afterward.
+    disconnections = [
+        (calc1, add1, IADD, lambda component: component.add(1, 2)),
+        (calc2, add1, IADD, lambda component: component.add(1, 2)),
+        (calc1, sub1, ISUB, lambda component: component.sub(1, 2)),
+        (calc2, sub1, ISUB, lambda component: component.sub(1, 2)),
+    ]
 
-try:
-    calc1 = addasuSec.create(PLAIN, CALC_CLASS, CALC1_NAME, False)
-    calc2 = addasuSec.create(PLAIN, CALC_CLASS, CALC2_NAME, False)
-    add1 = addasuSec.create(PLAIN, ADDER_CLASS, ADDER_NAME, False)
-
-    # Test delete + recreate
-    assert addasuSec.delete(PLAIN, ADDER_NAME)
-    add1 = addasuSec.create(PLAIN, ADDER_CLASS, ADDER_NAME, False)
-
-    sub1 = addasuSec.create(PLAIN, SUBBER_CLASS, SUBBER_NAME, False)
-
-except ComponentException as e:
-    sys.exit(f"Component creation failed: {e}")
-
-# === Invalid Creation and Deletion Tests ===
-
-try:
-    assert not addasuSec.delete(PLAIN, "Adder5")
-except ComponentException as e:
-    print(f"Expected error deleting non-existent component: {e}")
-
-try:
-    addasuSec.create(PLAIN, ADDER_CLASS, ADDER_NAME, False)
-except ComponentException as e:
-    print(f"Expected error on duplicate component creation: {e}")
-
-try:
-    addasuSec.create(PLAIN, ADDER_CLASS, "Adder 1", False)
-except ComponentException as e:
-    print(f"Expected error on invalid component name: {e}")
-
-# === Connection and Functionality Tests ===
-
-full_connection()
-run_tests()
-
-# === Disconnect and Negative Call Tests ===
-
-def test_disconnect_and_failures():
-    """Disconnect components and ensure calls fail."""
-    for c, t, iface in [
-        (calc1, add1, IADD),
-        (calc2, add1, IADD),
-        (calc1, sub1, ISUB),
-        (calc2, sub1, ISUB),
-    ]:
-        assert addasuSec.disconnect(PLAIN, c, t, iface)
+    for component, target, interface, operation in disconnections:
+        assert local_runtime.disconnect(RUNTIME_TYPE, component, target, interface)
         try:
-            # These calls should raise exceptions since disconnected
-            if iface == IADD:
-                c.add(1, 2)
-            else:
-                c.sub(1, 2)
-            assert False, "Disconnected call should not succeed"
+            # Any exception is acceptable here: the key contract is that the
+            # disconnected call must no longer succeed.
+            operation(component)
         except Exception:
-            pass
+            continue
+        raise AssertionError(
+            f"Disconnected call unexpectedly succeeded for interface {interface}"
+        )
 
     print("All disconnected calls failed as expected")
 
-test_disconnect_and_failures()
 
-# Reconnect for further testing
-full_connection()
-run_tests()
+def assert_metadata_updates():
+    """Verify interface attribute writes and reads across several components."""
+    # These updates exercise metadata storage independently of the runtime calls
+    # above. Each tuple is ``(component, interface, key, value)``.
+    updates = [
+        (CALC1_NAME, IADD, "Variation", 8),
+        (CALC1_NAME, IADD, "peter", "bob"),
+        (CALC2_NAME, IADD, "Variation", 77),
+        (CALC1_NAME, ISUB, "Variation", 98),
+        (CALC2_NAME, ISUB, "Variation", 87),
+    ]
 
-# === Metadata Tests ===
+    for component_name, interface, key, value in updates:
+        meta.setInterfaceAttributeValue(component_name, interface, key, value)
+        # Read back immediately so the failing key is obvious if a write does not
+        # persist correctly.
+        assert meta.getInterfaceAttributeValue(component_name, interface, key) == value
 
-addasuMeta.setInterfaceAttributeValue(CALC1_NAME, IADD, "Variation", 8)
-assert addasuMeta.getInterfaceAttributeValue(CALC1_NAME, IADD, "Variation") == 8
+    print("Metadata attribute tests passed")
 
-addasuMeta.setInterfaceAttributeValue(CALC1_NAME, IADD, "peter", "bob")
-assert addasuMeta.getInterfaceAttributeValue(CALC1_NAME, IADD, "peter") == "bob"
 
-addasuMeta.setInterfaceAttributeValue(CALC2_NAME, IADD, "Variation", 77)
-assert addasuMeta.getInterfaceAttributeValue(CALC2_NAME, IADD, "Variation") == 77
+def print_connection_summary():
+    """Print connection information that is useful during manual debugging."""
+    # These reports are intentionally left as prints because they are useful when
+    # manually inspecting the current architecture after the assertions pass.
+    print(f"\nConnections to {ADDER_NAME} {IADD}:")
+    for name in meta.connectionsToIntf(ADDER_NAME, IADD):
+        print(f" -> {name}")
 
-addasuMeta.setInterfaceAttributeValue(CALC1_NAME, ISUB, "Variation", 98)
-assert addasuMeta.getInterfaceAttributeValue(CALC1_NAME, ISUB, "Variation") == 98
+    print(f"\nConnections from {CALC1_NAME} {IADD}:")
+    for name in meta.connectionsFromRecp(CALC1_NAME, IADD):
+        print(f" -> {name}")
 
-addasuMeta.setInterfaceAttributeValue(CALC2_NAME, ISUB, "Variation", 87)
-assert addasuMeta.getInterfaceAttributeValue(CALC2_NAME, ISUB, "Variation") == 87
+    print(f"\nConnections from {CALC1_NAME} {ISUB}:")
+    for name in meta.connectionsFromRecp(CALC1_NAME, ISUB):
+        print(f" -> {name}")
 
-print("Metadata attribute tests passed")
 
-# === Interface & Connection Inspection ===
+def print_component_summary():
+    """Print interfaces, receptacles, and the current component list."""
+    print("\nInterfaces and Receptacles:")
+    for component_name in [CALC1_NAME, CALC2_NAME, ADDER_NAME, SUBBER_NAME]:
+        print(f"Interfaces on {component_name}: {meta.getInterfaces(component_name)}")
 
-print("\nConnections to Adder1 IAdd:")
-for name in addasuMeta.connectionsToIntf(ADDER_NAME, IADD):
-    print(f"↳ {name}")
+    print(f"Receptacles on {CALC1_NAME}: {meta.getReceptacles(CALC1_NAME)}")
+    print(f"Receptacles on {ADDER_NAME}: {meta.getReceptacles(ADDER_NAME)}")
 
-print("\nConnections from Calculator1 IAdd:")
-for name in addasuMeta.connectionsFromRecp(CALC1_NAME, IADD):
-    print(f"↳ {name}")
+    print("\nAll Components:")
+    all_components = meta.getAllComponents()
+    print(all_components)
+    # ``Calculator2`` is checked here so the final deletion test can prove that
+    # the component list actually changes afterward.
+    assert CALC2_NAME in all_components
 
-print("\nConnections from Calculator1 ISub:")
-for name in addasuMeta.connectionsFromRecp(CALC1_NAME, ISUB):
-    print(f"↳ {name}")
 
-# === Introspection ===
+def main():
+    # Phase 1: create a small component graph that will be reused across all
+    # later checks in this script.
+    calc1 = create_component(CALC_CLASS, CALC1_NAME)
+    calc2 = create_component(CALC_CLASS, CALC2_NAME)
+    add1 = create_component(ADDER_CLASS, ADDER_NAME)
 
-print("\nInterfaces and Receptacles:")
-for comp in [CALC1_NAME, CALC2_NAME, ADDER_NAME, SUBBER_NAME]:
-    print(f"Interfaces on {comp}: {addasuMeta.getInterfaces(comp)}")
+    # Delete and recreate one component to prove the runtime cleans up correctly
+    # and allows the same logical label to be used again.
+    assert local_runtime.delete(RUNTIME_TYPE, ADDER_NAME)
+    add1 = create_component(ADDER_CLASS, ADDER_NAME)
 
-print(f"Receptacles on {CALC1_NAME}: {addasuMeta.getReceptacles(CALC1_NAME)}")
-print(f"Receptacles on {ADDER_NAME}: {addasuMeta.getReceptacles(ADDER_NAME)}")
+    sub1 = create_component(SUBBER_CLASS, SUBBER_NAME)
 
-# === List All Components ===
+    # Phase 2: validate common failure cases that the runtime should reject.
+    assert not local_runtime.delete(RUNTIME_TYPE, "Adder5")
+    expect_component_error(
+        lambda: local_runtime.create(RUNTIME_TYPE, ADDER_CLASS, ADDER_NAME, False),
+        "duplicate component creation",
+    )
+    expect_component_error(
+        lambda: local_runtime.create(RUNTIME_TYPE, ADDER_CLASS, "Adder 1", False),
+        "invalid component name",
+    )
 
-print("\nAll Components:")
-all_comps = addasuMeta.getAllComponents()
-print(all_comps)
-assert CALC2_NAME in all_comps
+    # Phase 3: connect the graph and prove that delegated operations work.
+    connect_all(calc1, calc2, add1, sub1)
+    assert_basic_operations(calc1, calc2)
 
-# === Final Deletion ===
+    # Phase 4: remove each dependency and confirm that calls fail once the graph
+    # has been torn down.
+    disconnect_and_assert_failures(calc1, calc2, add1, sub1)
 
-assert addasuSec.delete(PLAIN, CALC2_NAME)
-all_comps = addasuMeta.getAllComponents()
-assert CALC2_NAME not in all_comps
-print(f"{CALC2_NAME} successfully deleted.")
+    # Phase 5: reconnect the graph to confirm the runtime can recover cleanly
+    # after disconnection.
+    connect_all(calc1, calc2, add1, sub1)
+    assert_basic_operations(calc1, calc2)
+
+    # Phase 6: exercise metadata and reporting APIs after the structural tests.
+    assert_metadata_updates()
+    print_connection_summary()
+    print_component_summary()
+
+    # Phase 7: remove a component and verify that the architecture view updates.
+    assert local_runtime.delete(RUNTIME_TYPE, CALC2_NAME)
+    all_components = meta.getAllComponents()
+    assert CALC2_NAME not in all_components
+    print(f"{CALC2_NAME} successfully deleted.")
+
+
+if __name__ == "__main__":
+    # Keep the script executable as a direct entrypoint for local manual testing.
+    main()

--- a/tests/LocalTests/mainRemote.py
+++ b/tests/LocalTests/mainRemote.py
@@ -1,142 +1,189 @@
+"""Remote integration checks for Addasu components.
+
+This script drives a remote runtime endpoint, creates a small component graph,
+connects and disconnects it, triggers execution through the start component,
+and prints metadata and introspection state for manual inspection.
 """
-RemoteComponentManager.py
 
-Remotely creates, connects, and inspects Addasu components using secure runtime.
-
-Author: Paul Grace
-"""
-
-from AddasuSec.Receptacle import Receptacle
-from Runtimes.runtime import runtime, ComponentException, ConnectionException
-from MetaArchitecture.MetaArchitecture import MetaArchitecture
-
-import os
 import sys
+from pathlib import Path
 
-# === Constants ===
+# Allow the script to be executed directly from ``tests/LocalTests`` while still
+# importing packages from the repository's ``src`` layout.
+PROJECT_SRC = Path(__file__).resolve().parents[2] / "src"
+if str(PROJECT_SRC) not in sys.path:
+    # Prefer the checked-out source tree over any globally installed version.
+    sys.path.insert(0, str(PROJECT_SRC))
+
+from MetaArchitecture.MetaArchitecture import MetaArchitecture
+from Runtimes.runtime import ComponentException, ConnectionException, runtime
+
+# Base URL for the remote runtime process that hosts the components.
 REMOTE_RUNTIME = "http://localhost:8654"
+RUNTIME_TYPE = "plain"
 
+# Stable labels used for creation, metadata queries, and connection reports.
 CALC1 = "Calculator1"
 CALC2 = "Calculator2"
 ADDER = "Adder1"
 SUBBER = "Subber1"
 START = "Start1"
 
+# Interfaces used by the example components.
+ICALCULATE = "Examples.ICalculate"
 IADD = "Examples.IAdd"
 ISUB = "Examples.ISub"
 
-# === Initialise Runtime and MetaArchitecture ===
+# ``MetaArchitecture`` tracks the architecture model locally while the runtime
+# proxy issues create/connect/start requests to the remote address space.
 meta = MetaArchitecture()
-secure_runtime = runtime(meta)
+remote_runtime = runtime(meta)
 
-# === Helper Functions ===
 
 def safe_create(label, module):
+    """Create a remote component and report the result."""
     try:
-        comp = secure_runtime.remoteCreate(REMOTE_RUNTIME, "plain", module, label, False)
-        print(f"✅ Created {label} ({module}) → ID: {meta.getLabel(comp)}")
-        return comp
-    except ComponentException as e:
-        print(f"⚠️  Failed to create {label} ({module}): {e}")
+        component = remote_runtime.remoteCreate(
+            REMOTE_RUNTIME, RUNTIME_TYPE, module, label, False
+        )
+        print(f"Created {label} ({module}) -> ID: {meta.getLabel(component)}")
+        return component
+    except ComponentException as exc:
+        # Duplicate names and invalid definitions are expected in some checks, so
+        # report them and let the script continue.
+        print(f"Failed to create {label} ({module}): {exc}")
         return None
 
-def safe_connect(src_id, tgt_id, intf):
+
+def safe_connect(source_id, target_id, interface):
+    """Connect two remote components and print the outcome."""
     try:
-        if secure_runtime.remoteConnect(REMOTE_RUNTIME, "plain", src_id, tgt_id, intf):
-            print(f"🔗 Connected {meta.getLabel(src_id)} → {meta.getLabel(tgt_id)} ({intf})")
-    except ConnectionException as e:
-        print(f"❌ Failed to connect {src_id} → {tgt_id}: {e}")
-        
-def safe_disconnect(src_id, tgt_id, intf):
+        if remote_runtime.remoteConnect(
+            REMOTE_RUNTIME, RUNTIME_TYPE, source_id, target_id, interface
+        ):
+            print(
+                f"Connected {meta.getLabel(source_id)} -> "
+                f"{meta.getLabel(target_id)} ({interface})"
+            )
+    except ConnectionException as exc:
+        print(f"Failed to connect {source_id} -> {target_id}: {exc}")
+
+
+def safe_disconnect(source_id, target_id, interface):
+    """Disconnect two remote components and print the outcome."""
     try:
-        if secure_runtime.remoteDisconnect(REMOTE_RUNTIME, "plain", src_id, tgt_id, intf):
-            print(f"🔗 Disconnected {meta.getLabel(src_id)} → {meta.getLabel(tgt_id)} ({intf})")
-    except ConnectionException as e:
-        print(f"❌ Failed to connect {src_id} → {tgt_id}: {e}")
-
-def print_connections(title, conn_list):
-    print(f"\n🔍 {title}")
-    for c in conn_list:
-        print(f" ↳ {c}")
-
-# === Component Creation ===
-
-print("\n=== 🚀 Creating Components ===")
-start1 = safe_create(START, "Examples.CalculatorStart")
-calc1 = safe_create(CALC1, "Examples.Calculator")
-calc2 = safe_create(CALC2, "Examples.Calculator")
-add1 = safe_create(ADDER, "Examples.Adder")
-sub1 = safe_create(SUBBER, "Examples.Subber")
-
-# Intentional duplicate (should fail)
-print("\n=== ⚠️ Duplicate Component Creation Test ===")
-safe_create(ADDER, "Examples.Adder")
-
-# === Component Connections ===
-
-print("\n=== 🔗 Connecting Components ===")
-safe_connect(start1, calc1, "Examples.ICalculate")
-safe_connect(calc1, add1, IADD)
-safe_connect(calc2, add1, IADD)
-safe_connect(calc1, sub1, ISUB)
-safe_connect(calc2, sub1, ISUB)
-
-# === Test component configuration runs ===
-secure_runtime.remoteStart(REMOTE_RUNTIME, "plain", start1)
-
-# === Test disconnects ===
+        if remote_runtime.remoteDisconnect(
+            REMOTE_RUNTIME, RUNTIME_TYPE, source_id, target_id, interface
+        ):
+            print(
+                f"Disconnected {meta.getLabel(source_id)} -> "
+                f"{meta.getLabel(target_id)} ({interface})"
+            )
+    except ConnectionException as exc:
+        print(f"Failed to disconnect {source_id} -> {target_id}: {exc}")
 
 
-for c, t, iface in [
+def print_connections(title, connections):
+    """Render connection lists in a readable format for manual inspection."""
+    print(f"\n{title}")
+    for connection in connections:
+        print(f" -> {connection}")
+
+
+def connect_application(start1, calc1, calc2, add1, sub1):
+    """Wire the start component to the calculator graph and service providers."""
+    safe_connect(start1, calc1, ICALCULATE)
+    safe_connect(calc1, add1, IADD)
+    safe_connect(calc2, add1, IADD)
+    safe_connect(calc1, sub1, ISUB)
+    safe_connect(calc2, sub1, ISUB)
+
+
+def disconnect_application(calc1, calc2, add1, sub1):
+    """Remove the calculator-to-service bindings one by one."""
+    for component, target, interface in [
         (calc1, add1, IADD),
         (calc2, add1, IADD),
         (calc1, sub1, ISUB),
         (calc2, sub1, ISUB),
     ]:
-    safe_disconnect(c, t, iface)
-    secure_runtime.remoteStart(REMOTE_RUNTIME, "plain", start1)
-
-# === Call start to see if the configuration runs ===
-print("\n=== 🔗 Connecting Components Again===")
-safe_connect(calc1, add1, IADD)
-safe_connect(calc2, add1, IADD)
-safe_connect(calc1, sub1, ISUB)
-safe_connect(calc2, sub1, ISUB)
-secure_runtime.remoteStart(REMOTE_RUNTIME, "plain", start1)
+        safe_disconnect(component, target, interface)
 
 
-print("\n=== 🧪 Metadata Attribute Test ===")
-meta.setInterfaceAttributeValue(CALC1, IADD, "Variation", 8)
-variation_val = meta.getInterfaceAttributeValue(CALC1, IADD, "Variation")
-print(f"📌 {CALC1}.{IADD}.Variation = {variation_val}")
+def main():
+    # Phase 1: create the remote components needed for the runtime scenario.
+    print("\nCreating components")
+    start1 = safe_create(START, "Examples.CalculatorStart")
+    calc1 = safe_create(CALC1, "Examples.Calculator")
+    calc2 = safe_create(CALC2, "Examples.Calculator")
+    add1 = safe_create(ADDER, "Examples.Adder")
+    sub1 = safe_create(SUBBER, "Examples.Subber")
 
-# === Inspection & Debugging ===
+    # Intentionally repeat one label to confirm the remote runtime rejects
+    # duplicate component creation requests.
+    print("\nDuplicate component creation test")
+    safe_create(ADDER, "Examples.Adder")
 
-print_connections(f"Connections TO {ADDER}.{IADD}", meta.connectionsToIntf(ADDER, IADD))
-print_connections(f"Connections FROM {CALC1}.{IADD}", meta.connectionsFromRecp(CALC1, IADD))
-print_connections(f"Connections FROM {CALC1}.{ISUB}", meta.connectionsFromRecp(CALC1, ISUB))
+    # Phase 2: connect the graph and trigger execution through the start
+    # component so the remote runtime exercises the assembled configuration.
+    print("\nConnecting components")
+    connect_application(start1, calc1, calc2, add1, sub1)
+    remote_runtime.remoteStart(REMOTE_RUNTIME, RUNTIME_TYPE, start1)
 
-# === Interface & Receptacle Introspection ===
+    # Phase 3: disconnect each dependency and start the configuration after each
+    # change so the effect of the missing binding can be observed remotely.
+    print("\nDisconnecting components")
+    for component, target, interface in [
+        (calc1, add1, IADD),
+        (calc2, add1, IADD),
+        (calc1, sub1, ISUB),
+        (calc2, sub1, ISUB),
+    ]:
+        safe_disconnect(component, target, interface)
+        remote_runtime.remoteStart(REMOTE_RUNTIME, RUNTIME_TYPE, start1)
 
-print("\n=== 🧠 Interface Inspection ===")
-for comp in [CALC1, CALC2, ADDER, SUBBER]:
-    print(f"Interfaces on {comp}: {meta.getInterfaces(comp)}")
+    # Phase 4: rebuild the graph and run it again to confirm the configuration
+    # can recover after the disconnect sequence.
+    print("\nReconnecting components")
+    connect_application(start1, calc1, calc2, add1, sub1)
+    remote_runtime.remoteStart(REMOTE_RUNTIME, RUNTIME_TYPE, start1)
 
-print("\n=== 🧠 Receptacle Inspection ===")
-for comp in [CALC2, ADDER, SUBBER]:
-    print(f"Receptacles on {comp}: {meta.getReceptacles(comp)}")
+    # Phase 5: verify metadata read/write behavior using one of the interfaces.
+    print("\nMetadata attribute test")
+    meta.setInterfaceAttributeValue(CALC1, IADD, "Variation", 8)
+    variation_value = meta.getInterfaceAttributeValue(CALC1, IADD, "Variation")
+    print(f"{CALC1}.{IADD}.Variation = {variation_value}")
 
-# === Component Listing & Deletion ===
+    # Phase 6: print the current architectural model for manual debugging.
+    print_connections(f"Connections TO {ADDER}.{IADD}", meta.connectionsToIntf(ADDER, IADD))
+    print_connections(
+        f"Connections FROM {CALC1}.{IADD}", meta.connectionsFromRecp(CALC1, IADD)
+    )
+    print_connections(
+        f"Connections FROM {CALC1}.{ISUB}", meta.connectionsFromRecp(CALC1, ISUB)
+    )
 
-print("\n=== 📋 All Components (Before Deletion) ===")
-all_comps_before = meta.getAllComponents()
-print(all_comps_before)
+    print("\nInterface inspection")
+    for component_name in [CALC1, CALC2, ADDER, SUBBER]:
+        print(f"Interfaces on {component_name}: {meta.getInterfaces(component_name)}")
 
-print(f"\n🗑️ Deleting {CALC2}")
-secure_runtime.delete("plain", CALC2)
+    print("\nReceptacle inspection")
+    for component_name in [CALC2, ADDER, SUBBER]:
+        print(f"Receptacles on {component_name}: {meta.getReceptacles(component_name)}")
 
-print("\n📋 All Components (After Deletion):")
-all_comps_after = meta.getAllComponents()
-print(all_comps_after)
+    # Phase 7: show the complete component list before and after deleting one
+    # component so the remote runtime cleanup is visible in the meta-model.
+    print("\nAll components before deletion")
+    all_components_before = meta.getAllComponents()
+    print(all_components_before)
+
+    print(f"\nDeleting {CALC2}")
+    remote_runtime.delete(RUNTIME_TYPE, CALC2)
+
+    print("\nAll components after deletion")
+    all_components_after = meta.getAllComponents()
+    print(all_components_after)
 
 
+if __name__ == "__main__":
+    main()

--- a/tests/LocalTests/mainSecure.py
+++ b/tests/LocalTests/mainSecure.py
@@ -14,11 +14,17 @@ Test Validations:
 - Component list and deletion
 """
 
+import requests
+import sys
+from pathlib import Path
+
+PROJECT_SRC = Path(__file__).resolve().parents[2] / "src"
+if str(PROJECT_SRC) not in sys.path:
+    sys.path.insert(0, str(PROJECT_SRC))
+
 from AddasuSec.Receptacle import Receptacle
 from Runtimes.runtime import runtime, ComponentException, ConnectionException
 from MetaArchitecture.MetaArchitecture import MetaArchitecture
-import requests
-import sys
 
 # Constants for reuse
 RUNTIME_TYPE = "plain"


### PR DESCRIPTION
Add VS Code test/settings (pytest args, extraPaths) and a new DevelopingWebBasedComponents guide. Update WritingComponentsGuide.md to remove stray lines. Make WebRuntime.py insert the repository src path into sys.path for direct test execution. Add a brief module docstring to WebAPI.py. Refactor tests/LocalTests (main.py, mainRemote.py, mainSecure.py): prepend src to sys.path, reorganize into helper functions and a main(), improve error handling, prints and remote runtime calls so the local and remote test scripts are more robust and runnable from the tests directory.